### PR TITLE
Wrap disabled buttons in tooltips

### DIFF
--- a/frontend/src/pages/Map2DPage.tsx
+++ b/frontend/src/pages/Map2DPage.tsx
@@ -456,22 +456,26 @@ const Map2DPage: React.FC<Map2DPageProps> = ({
 
         <Box>
           <Tooltip title="Force refresh map data">
-            <IconButton
-              onClick={() => fetchMapData(true)}
-              disabled={loading}
-              color="primary"
-            >
-              <RefreshIcon />
-            </IconButton>
+            <span style={{ display: 'inline-block' }}>
+              <IconButton
+                onClick={() => fetchMapData(true)}
+                disabled={loading}
+                color="primary"
+              >
+                <RefreshIcon />
+              </IconButton>
+            </span>
           </Tooltip>
           <Tooltip title="Save the current map">
-            <IconButton
-              onClick={() => handleSaveMap()}
-              disabled={loading}
-              color="primary"
-            >
-              <SaveIcon />
-            </IconButton>
+            <span style={{ display: 'inline-block' }}>
+              <IconButton
+                onClick={() => handleSaveMap()}
+                disabled={loading}
+                color="primary"
+              >
+                <SaveIcon />
+              </IconButton>
+            </span>
           </Tooltip>
         </Box>
       </Box>

--- a/frontend/src/pages/NodesPage.tsx
+++ b/frontend/src/pages/NodesPage.tsx
@@ -296,37 +296,43 @@ const NodesPage: React.FC<NodesPageProps> = ({ isConnected, onCommand, systemDat
                   <Box sx={{ display: 'flex', gap: 1 }}>
                     {node.status === 'stopped' || node.status === 'error' ? (
                       <Tooltip title="Start Node">
-                        <IconButton
-                          size="small"
-                          onClick={() => handleNodeAction(node.name, 'start')}
-                          disabled={loading || !isConnected}
-                          color="success"
-                        >
-                          <PlayArrow />
-                        </IconButton>
+                        <span style={{ display: 'inline-block' }}>
+                          <IconButton
+                            size="small"
+                            onClick={() => handleNodeAction(node.name, 'start')}
+                            disabled={loading || !isConnected}
+                            color="success"
+                          >
+                            <PlayArrow />
+                          </IconButton>
+                        </span>
                       </Tooltip>
                     ) : (
                       <Tooltip title="Stop Node">
-                        <IconButton
-                          size="small"
-                          onClick={() => handleNodeAction(node.name, 'stop')}
-                          disabled={loading || !isConnected}
-                          color="error"
-                        >
-                          <Stop />
-                        </IconButton>
+                        <span style={{ display: 'inline-block' }}>
+                          <IconButton
+                            size="small"
+                            onClick={() => handleNodeAction(node.name, 'stop')}
+                            disabled={loading || !isConnected}
+                            color="error"
+                          >
+                            <Stop />
+                          </IconButton>
+                        </span>
                       </Tooltip>
                     )}
-                    
+
                     <Tooltip title="Restart Node">
-                      <IconButton
-                        size="small"
-                        onClick={() => handleNodeAction(node.name, 'restart')}
-                        disabled={loading || !isConnected}
-                        color="warning"
-                      >
-                        <Refresh />
-                      </IconButton>
+                      <span style={{ display: 'inline-block' }}>
+                        <IconButton
+                          size="small"
+                          onClick={() => handleNodeAction(node.name, 'restart')}
+                          disabled={loading || !isConnected}
+                          color="warning"
+                        >
+                          <Refresh />
+                        </IconButton>
+                      </span>
                     </Tooltip>
                   </Box>
                 </TableCell>


### PR DESCRIPTION
## Summary
- Prevent MUI warnings by wrapping disabled icon buttons with spans so Tooltip events still fire
- Apply span wrapper to map refresh/save buttons in 2D map page
- Apply span wrapper to node action buttons in Nodes page

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a565aa5068832485811f0dc27313c4